### PR TITLE
fix sd_step command

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,4 +3,4 @@ jobs:
         image: golang:latest
         steps:
             - print: echo this is shared-steps test main job
-            - sd_step: /opt/sd/sd-step exec core/node node -v
+            - sd_step: /opt/sd/sd-step exec core/node "node -v"


### PR DESCRIPTION
I found  that result of `sd_step` step is different from expected result.

```
$ /opt/sd/sd-step exec core/node node -v
Incorrect Usage: flag provided but not defined: -v

NAME:
   sd-step exec - Install and exec habitat package with pkg_name and command...
USAGE:
   sd-step exec [command options] [arguments...]
OPTIONS:
   --pkg-version value  Package version
```
This is because arguments are not properly quoted. 