### PR TITLE
add steps for semver test

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,7 +3,7 @@ jobs:
         image: golang:latest
         steps:
             - print: echo this is shared-steps test main job
-            - sd_step: /opt/sd/sd-step exec core/node "node -v"
-            - sd_step_childa: /opt/sd/sd-step exec --pkg-version "~6.9.0" core/node "node -v"
-            - sd_step_hat: /opt/sd/sd-step exec --pkg-version "^6.0.0" core/node "node -v"
-            - sd_step_specify: /opt/sd/sd-step exec --pkg-version "4.2.6" core/node "node -v"
+            - sd_step: sd-step exec core/node "node -v"
+            - sd_step_tilda: sd-step exec --pkg-version "~6.9.0" core/node "node -v"
+            - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"
+            - sd_step_specify: sd-step exec --pkg-version "4.2.6" core/node "node -v"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,3 +4,6 @@ jobs:
         steps:
             - print: echo this is shared-steps test main job
             - sd_step: /opt/sd/sd-step exec core/node "node -v"
+            - sd_step_childa: /opt/sd/sd-step exec --pkg-version "~6.9.0" core/node "node -v"
+            - sd_step_hat: /opt/sd/sd-step exec --pkg-version "^6.0.0" core/node "node -v"
+            - sd_step_specify: /opt/sd/sd-step exec --pkg-version "4.2.6" core/node "node -v"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,6 +4,6 @@ jobs:
         steps:
             - print: echo this is shared-steps test main job
             - sd_step: sd-step exec core/node "node -v"
-            - sd_step_tilda: sd-step exec --pkg-version "~6.9.0" core/node "node -v"
+            - sd_step_tilde: sd-step exec --pkg-version "~6.9.0" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"
             - sd_step_specify: sd-step exec --pkg-version "4.2.6" core/node "node -v"


### PR DESCRIPTION
added some steps to the main job for sd-step semver functional test.

Actually, I'd like to separate jobs rather than adding to steps, 

e.g.
```
jobs:
    main:
        image: golang:latest
        steps:
            - print: echo this is shared-steps test main job
    tilde:
        image: golang:latest
        steps:
            - print: echo this is shared-steps test childa job
            - sd_step: /opt/sd/sd-step exec --pkg-version "~6.9.0" core/node "node -v"
    hat:
        image: golang:latest
        steps:
            - print: echo this is shared-steps test hat job
            - sd_step: /opt/sd/sd-step exec --pkg-version "^6.0.0" core/node "node -v"
```

But currently, all jobs are triggered without defining a workflow when executing a functional test, so I decided to add it to the step.

Related to https://github.com/screwdriver-cd/sd-step/pull/3

Requirement:   >= screwdrivercd/launcher:~v4.0.20~ v4.0.27