### PR TITLE
fix: switch to 6.11.X sind 6.9.X is not tag as stable

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,6 +4,6 @@ jobs:
         steps:
             - print: echo this is shared-steps test main job
             - sd_step: sd-step exec core/node "node -v"
-            - sd_step_tilde: sd-step exec --pkg-version "~6.9.0" core/node "node -v"
+            - sd_step_tilde: sd-step exec --pkg-version "~6.11.0" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"
             - sd_step_specify: sd-step exec --pkg-version "4.2.6" core/node "node -v"


### PR DESCRIPTION
Switch to 6.11.X sind 6.9.X is not tag as stable
This is failing our functional tests.
https://bldr.habitat.sh/#/pkgs/core/node