### PR TITLE
fix: use new workflow

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -7,3 +7,6 @@ jobs:
             - sd_step_tilde: sd-step exec --pkg-version "~6.11.0" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"
             - sd_step_specify: sd-step exec --pkg-version "4.2.6" core/node "node -v"
+        requires:
+            - ~pr
+            - ~commit


### PR DESCRIPTION
Deprecating old workflow

Related: https://github.com/screwdriver-cd/screwdriver/issues/723