### PR TITLE
fix: Update node package version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ jobs:
     main:
         image: golang:latest
         steps:
-            - print: echo this is shared-steps test main job
+            - print: echo this is shared-steps test main job && sleep 1000
             - sd_step: sd-step exec core/node "node -v"
             - sd_step_tilde: sd-step exec --pkg-version "~6.11.3" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -4,7 +4,7 @@ jobs:
         steps:
             - print: echo this is shared-steps test main job
             - sd_step: sd-step exec core/node "node -v"
-            - sd_step_tilde: sd-step exec --pkg-version "~6.11.0" core/node "node -v"
+            - sd_step_tilde: sd-step exec --pkg-version "~6.11.3" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"
             - sd_step_specify: sd-step exec --pkg-version "4.2.6" core/node "node -v"
         requires:

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -2,7 +2,7 @@ jobs:
     main:
         image: golang:latest
         steps:
-            - print: echo this is shared-steps test main job && sleep 1000
+            - print: echo this is shared-steps test main job
             - sd_step: sd-step exec core/node "node -v"
             - sd_step_tilde: sd-step exec --pkg-version "~6.11.3" core/node "node -v"
             - sd_step_hat: sd-step exec --pkg-version "^6.0.0" core/node "node -v"


### PR DESCRIPTION
The `sd_step_tilde` step is failing consistently for `6.11.0`. This PR attempts to fix the step by using an alternative version that exists at the location.

https://willem.habitat.sh/#/pkgs/core/node